### PR TITLE
Translations catch-up - Batch 1

### DIFF
--- a/Translated/jobname.xml
+++ b/Translated/jobname.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ms2>
-	<key id="10" name="Knight" />
+	<key id="10" name="Beginner" />
 	<key id="100" name="Knight" feature="" />
 	<key id="101" name="Knight II" feature="JobChange_01" />
 	<key id="200" name="Berserker" feature="" />

--- a/Translated/npcname.xml
+++ b/Translated/npcname.xml
@@ -3277,10 +3277,10 @@
 	<key id="11004568" name="Mika" feature="Colosseum01" />
 	<key id="11004569" name="MC Nagi" feature="Colosseum01" />
 	<key id="11004570" name="MC Nagi" feature="Colosseum01" />
-	<key id="11004571" name="Refugee Man" feature="Kritias_Epic02" />
-	<key id="11004572" name="Refugee Woman" feature="Kritias_Epic02" />
-	<key id="11004573" name="Refugee Child" feature="Kritias_Epic02" />
-	<key id="11004574" name="Refugee Leader" feature="Kritias_Epic02" />
+	<key id="11004571" name="Gregor" feature="Kritias_Epic02" />
+	<key id="11004572" name="Helen" feature="Kritias_Epic02" />
+	<key id="11004573" name="Ella" feature="Kritias_Epic02" />
+	<key id="11004574" name="Tessa" feature="Kritias_Epic02" />
 	<key id="11004575" name="Jessica" feature="Kritias_Epic02" />
 	<key id="11004576" name="Yorang" feature="Kritias_Epic02" />
 	<key id="11004577" name="Veliche" feature="Kritias_Epic02" />
@@ -3430,9 +3430,9 @@
 	<key id="11004724" name="Asimov" feature="Wedding" />
 	<key id="11004725" name="Namid" feature="Wedding" />
 	<key id="11004726" name="Illuna" feature="Event" />
-	<key id="11004727" name="어둠의 물질" feature="EpicApocalypse01" />
+	<key id="11004727" name="Dark Matter" feature="EpicApocalypse01" />
 	<key id="11004728" name="Hide-and-Seek Wheel" feature="MassiveHideAndSeek" />
-	<key id="11004733" name="Dede" feature="Wedding" />
+	<key id="11004733" name="DayDay" feature="Wedding" />
 	<key id="11004734" name="Ray" feature="Wedding" />
 	<key id="11004735" name="50 Meso" feature="Wedding" />
 	<key id="11004736" name="Meminem" feature="Wedding" />
@@ -3443,7 +3443,7 @@
 	<key id="11004741" name="Manuel" feature="Wedding" />
 	<key id="11004742" name="숨바꼭질 이벤트 스핀" feature="MassiveHideAndSeek" locale="CN" />
 	<key id="11004743" name="Rainbow Unicorn Pinata" feature="Wedding" />
-	<key id="11004744" name="바론" feature="EpicApocalypse01" />
+	<key id="11004744" name="Balon" feature="EpicApocalypse01" />
 	<key id="11004745" name="Happy" feature="Wedding" />
 	<key id="11004746" name="Ivy" feature="Wedding" />
 	<key id="11004747" name="Harmony Wiz" feature="Wedding" />
@@ -3484,53 +3484,53 @@
 	<key id="11004784" name="Luanna" feature="EpicApocalypse01" />
 	<key id="11004785" name="Ereve" feature="EpicApocalypse01" />
 	<key id="11004786" name="Ereve" feature="EpicApocalypse01" />
-	<key id="11004787" name="바론" feature="EpicApocalypse01" />
-	<key id="11004788" name="바론" feature="EpicApocalypse01" />
-	<key id="11004789" name="바론" feature="EpicApocalypse01" />
-	<key id="11004790" name="바론" feature="EpicApocalypse01" />
-	<key id="11004791" name="꿈 속 장면 확인" feature="EpicApocalypse01" />
-	<key id="11004792" name="바론의 감옥 입구" feature="EpicApocalypse01" />
-	<key id="11004793" name="바론" feature="EpicApocalypse01" />
-	<key id="11004794" name="어둠의 땅 입구" feature="EpicApocalypse01" />
+	<key id="11004787" name="Balon" feature="EpicApocalypse01" />
+	<key id="11004788" name="Balon" feature="EpicApocalypse01" />
+	<key id="11004789" name="Balon" feature="EpicApocalypse01" />
+	<key id="11004790" name="Balon" feature="EpicApocalypse01" />
+	<key id="11004791" name="Check out dream sequence" feature="EpicApocalypse01" />
+	<key id="11004792" name="Balon&#39;s Prison Entrance" feature="EpicApocalypse01" />
+	<key id="11004793" name="Balon" feature="EpicApocalypse01" />
+	<key id="11004794" name="Opening to the Land of Darkness" feature="EpicApocalypse01" />
 	<key id="11004795" name="Bella" feature="EpicApocalypse01" />
 	<key id="11004796" name="Bella" feature="EpicApocalypse01" />
 	<key id="11004797" name="Bella" feature="EpicApocalypse01" />
 	<key id="11004798" name="Black Mage" feature="EpicApocalypse01" />
 	<key id="11004799" name="Black Mage" feature="EpicApocalypse01" />
-	<key id="11004800" name="독방 입구" feature="EpicApocalypse01" />
-	<key id="11004801" name="시공의 균열" feature="EpicApocalypse01" />
+	<key id="11004800" name="Solitary entrance" feature="EpicApocalypse01" />
+	<key id="11004801" name="A Crack on the Wall" feature="EpicApocalypse01" />
 	<key id="11004802" name="Lanemone" feature="EpicApocalypse01" />
-	<key id="11004803" name="어둠의 물질" feature="EpicApocalypse01" />
-	<key id="11004804" name="어둠의 물질" feature="EpicApocalypse01" />
-	<key id="11004805" name="어둠의 물질" feature="EpicApocalypse01" />
-	<key id="11004806" name="어둠의 물질" feature="EpicApocalypse01" />
-	<key id="11004807" name="어둠의 물질" feature="EpicApocalypse01" />
-	<key id="11004808" name="어둠의 물질" feature="EpicApocalypse01" />
-	<key id="11004809" name="어둠의 물질" feature="EpicApocalypse01" />
-	<key id="11004810" name="어둠의 물질" feature="EpicApocalypse01" />
-	<key id="11004811" name="어둠의 물질" feature="EpicApocalypse01" />
-	<key id="11004812" name="어둠의 물질" feature="EpicApocalypse01" />
-	<key id="11004813" name="신성한 영혼" feature="EpicApocalypse01" />
-	<key id="11004814" name="청렴한 영혼" feature="EpicApocalypse01" />
-	<key id="11004815" name="정의로운 영혼" feature="EpicApocalypse01" />
+	<key id="11004803" name="Dark Matter" feature="EpicApocalypse01" />
+	<key id="11004804" name="Dark Matter" feature="EpicApocalypse01" />
+	<key id="11004805" name="Dark Matter" feature="EpicApocalypse01" />
+	<key id="11004806" name="Dark Matter" feature="EpicApocalypse01" />
+	<key id="11004807" name="Dark Matter" feature="EpicApocalypse01" />
+	<key id="11004808" name="Dark Matter" feature="EpicApocalypse01" />
+	<key id="11004809" name="Dark Matter" feature="EpicApocalypse01" />
+	<key id="11004810" name="Dark Matter" feature="EpicApocalypse01" />
+	<key id="11004811" name="Dark Matter" feature="EpicApocalypse01" />
+	<key id="11004812" name="Dark Matter" feature="EpicApocalypse01" />
+	<key id="11004813" name="Divine Soul" feature="EpicApocalypse01" />
+	<key id="11004814" name="Pure Soul" feature="EpicApocalypse01" />
+	<key id="11004815" name="Righteous Soul" feature="EpicApocalypse01" />
 	<key id="11004816" name="Lanemone" feature="EpicApocalypse01" />
 	<key id="11004817" name="Mari" feature="EpicApocalypse01" />
 	<key id="11004818" name="Lumiknight Mage" feature="EpicApocalypse01" />
 	<key id="11004819" name="Lumiknight Mage" feature="EpicApocalypse01" />
 	<key id="11004820" name="Ereve" feature="EpicApocalypse01" />
-	<key id="11004821" name="환영의 부부스" feature="EpicApocalypse01" />
-	<key id="11004822" name="환영의 호루스" feature="EpicApocalypse01" />
-	<key id="11004823" name="환영의 바야르" feature="EpicApocalypse01" />
-	<key id="11004824" name="환영의 마크52" feature="EpicApocalypse01" />
+	<key id="11004821" name="Phantom Booboo" feature="EpicApocalypse01" />
+	<key id="11004822" name="Phantom Horus" feature="EpicApocalypse01" />
+	<key id="11004823" name="Phantom Vayar" feature="EpicApocalypse01" />
+	<key id="11004824" name="Phantom MK52" feature="EpicApocalypse01" />
 	<key id="11004825" name="Ereve" feature="EpicApocalypse01" />
-	<key id="11004826" name="감옥 경비병" feature="EpicApocalypse01" />
-	<key id="11004827" name="시간여행자 블랙빈" feature="Event" />
+	<key id="11004826" name="Prison Guard" feature="EpicApocalypse01" />
+	<key id="11004827" name="Time Traveler Black Bean" feature="Event" />
 	<key id="11004828" name="Lanemone" feature="EpicApocalypse02" />
-	<key id="11004829" name="시공의 균열 중앙" feature="EpicApocalypse02" />
+	<key id="11004829" name="Center of the Crack on the Wall" feature="EpicApocalypse02" />
 	<key id="11004830" name="Dark Lord" feature="EpicApocalypse02" />
 	<key id="11004831" name="Black Bean" feature="EpicApocalypse02" />
 	<key id="11004832" name="Cerian" feature="EpicApocalypse02" />
-	<key id="11004833" name="시간여행자 블랙빈" feature="Event" />
+	<key id="11004833" name="Time Traveler Black Bean" feature="Event" />
 	<key id="11004834" name="프라이데이" feature="Event" locale="KR" />
 	<key id="11004835" name="벚나무" feature="Event" locale="KR" />
 	<key id="11004836" name="작은 벚나무" feature="Event" locale="KR" />
@@ -3939,9 +3939,9 @@
 	<key id="21001035" name="Poing" feature="Kritias_2018_12" />
 	<key id="21001036" name="Daemon Crystal" feature="Fieldwar01" />
 	<key id="21001037" name="Small Daemon Crystal" feature="Fieldwar01" />
-	<key id="21001042" name="신성한 영혼" feature="EpicApocalypse01" />
-	<key id="21001043" name="청렴한 영혼" feature="EpicApocalypse01" />
-	<key id="21001044" name="정의로운 영혼" feature="EpicApocalypse01" />
+	<key id="21001042" name="Divine Soul" feature="EpicApocalypse01" />
+	<key id="21001043" name="Pure Soul" feature="EpicApocalypse01" />
+	<key id="21001044" name="Righteous Soul" feature="EpicApocalypse01" />
 	<key id="21001045" name="왕궁 지하 박쥐" feature="EpicApocalypse01" />
 	<key id="21001046" name="왕궁 지하 박쥐" feature="EpicApocalypse01" />
 	<key id="21010201" name="Turka Army Zergling" feature="Kritias_Turka02" />

--- a/Translated/stringnpcai.xml
+++ b/Translated/stringnpcai.xml
@@ -469,29 +469,29 @@
 	<key id="COLOSSEUM__AI_VASARACHEN_COLOSSEUM__0" name="Not bad. But I&apos;m just getting started!" feature="Colosseum01" />
 	<key id="COLOSSEUM__AI_VASARACHEN_COLOSSEUM__1" name="Let&apos;s see how you handle this." feature="Colosseum01" />
 	<key id="COLOSSEUM__AI_VASARACHEN_COLOSSEUM__2" name="You&apos;re pretty good, but this time will be different." feature="Colosseum01" />
-	<key id="BOSS__AI_ARCHEON__0" name="엔진 과부화 진행 중………" feature="Kritias_Turka01" />
-	<key id="BOSS__AI_ARCHEON__1" name="목표를 섬멸하라………" feature="Kritias_Turka01" />
-	<key id="BOSS__AI_ARCHEON__2" name="폭주………폭주………" feature="Kritias_Turka01" />
-	<key id="BOSS__AI_ARCHEON__3" name="이상 발생……이상 발생……엔진 과열……이동…이동…" feature="Kritias_Turka01" />
-	<key id="BOSS__AI_ARCHEON__4" name="위잉………풀파워 전개!" feature="Kritias_Turka01" />
-	<key id="BOSS__AI_ARCHEON__5" name="목표 섬멸………" feature="Kritias_Turka01" />
-	<key id="BOSS__AI_ARCHEON__6" name="출력 오버 상태로 전환………목표 포착 " feature="Kritias_Turka01" />
-	<key id="BOSS__AI_ARCHEON__7" name="모두 섬멸………" feature="Kritias_Turka01" />
-	<key id="BOSS_QUEST__AI_ARCHEON__0" name="목표를 섬멸하라………" feature="Kritias_Turka01" />
-	<key id="BOSS_QUEST__AI_ARCHEON__1" name="폭주………폭주………" feature="Kritias_Turka01" />
-	<key id="BOSS_QUEST__AI_ARCHEON__2" name="파괴………한다………" feature="Kritias_Turka01" />
-	<key id="BOSS_QUEST__AI_ARCHEON__3" name="출력 오버 상태로 전환………목표 포착 " feature="Kritias_Turka01" />
-	<key id="BOSS_QUEST__AI_ARCHEON__4" name="모두 섬멸………" feature="Kritias_Turka01" />
-	<key id="COLOSSEUM__AI_MIEL_COLOSSEUM__0" name="널 다치게 하긴 싫어... 이쯤에서 그만하는 게 어떨까?" feature="Colosseum02" />
-	<key id="COLOSSEUM__AI_MIEL_COLOSSEUM__1" name="어쩔 수 없지. 빠르게 끝내는 게 좋겠어." feature="Colosseum02" />
-	<key id="COLOSSEUM__AI_ARCANEBLADER_COLOSSEUM__0" name="도망치는 게 좋을거다." feature="Colosseum02" />
-	<key id="COLOSSEUM__AI_ARCANEBLADER_COLOSSEUM__1" name="쉴새없이 움직여라..." feature="Colosseum02" />
-	<key id="COLOSSEUM__AI_ARCANEBLADER_COLOSSEUM__2" name="생각보다 끈질기군." feature="Colosseum02" />
-	<key id="COLOSSEUM__AI_ARCANEBLADER_COLOSSEUM__3" name="이걸로 끝이다." feature="Colosseum02" />
-	<key id="COLOSSEUM__AI_ARCANEBLADER_COLOSSEUM__4" name="따라 올 수 있겠어?" feature="Colosseum02" />
-	<key id="COLOSSEUM__AI_ARCANEBLADER_COLOSSEUM__5" name="겨우 그 정도로?" feature="Colosseum02" />
-	<key id="COLOSSEUM__AI_ARCANEBLADER_COLOSSEUM__6" name="따라 올 수 있겠어?" feature="Colosseum02" />
-	<key id="WEDDING_PINATA_IRON_0" name="용사들의 결혼식이라더니\n별 것 없군!" feature="Wedding" />
-	<key id="WEDDING_PINATA_IRON_1" name="달달한 건 몽땅 내거야!\n건들지마!" feature="Wedding" />
-	<key id="WEDDING_PINATA_IRON_2" name="이번 결혼식도 망쳐주겠다!" feature="Wedding" />
+	<key id="BOSS__AI_ARCHEON__0" name="Engine overload in progress........" feature="Kritias_Turka01" />
+	<key id="BOSS__AI_ARCHEON__1" name="Exterminate the target........" feature="Kritias_Turka01" />
+	<key id="BOSS__AI_ARCHEON__2" name="Overload...overload..." feature="Kritias_Turka01" />
+	<key id="BOSS__AI_ARCHEON__3" name="Anomaly...Anomaly...Engine overheart...Move...Move..." feature="Kritias_Turka01" />
+	<key id="BOSS__AI_ARCHEON__4" name="Whizz...full power deployment!" feature="Kritias_Turka01" />
+	<key id="BOSS__AI_ARCHEON__5" name="Target annihilation........" feature="Kritias_Turka01" />
+	<key id="BOSS__AI_ARCHEON__6" name="Switching to state Output-Over... capturing target." feature="Kritias_Turka01" />
+	<key id="BOSS__AI_ARCHEON__7" name="Annihilating all of........" feature="Kritias_Turka01" />
+	<key id="BOSS_QUEST__AI_ARCHEON__0" name="Exterminate the target........" feature="Kritias_Turka01" />
+	<key id="BOSS_QUEST__AI_ARCHEON__1" name="Overload...overload..." feature="Kritias_Turka01" />
+	<key id="BOSS_QUEST__AI_ARCHEON__2" name="Going to........destroy........" feature="Kritias_Turka01" />
+	<key id="BOSS_QUEST__AI_ARCHEON__3" name="Switching to state Output-Over... capturing target." feature="Kritias_Turka01" />
+	<key id="BOSS_QUEST__AI_ARCHEON__4" name="Annihilating all of........" feature="Kritias_Turka01" />
+	<key id="COLOSSEUM__AI_MIEL_COLOSSEUM__0" name="I don&#39;t want to hurt you... Why don&#39;t we stop here?" feature="Colosseum02" />
+	<key id="COLOSSEUM__AI_MIEL_COLOSSEUM__1" name="Well, if there is nothing I can do... We&#39;d better get this over quickly." feature="Colosseum02" />
+	<key id="COLOSSEUM__AI_ARCANEBLADER_COLOSSEUM__0" name="It would be better to run away." feature="Colosseum02" />
+	<key id="COLOSSEUM__AI_ARCANEBLADER_COLOSSEUM__1" name="Don&#39;t stop moving..." feature="Colosseum02" />
+	<key id="COLOSSEUM__AI_ARCANEBLADER_COLOSSEUM__2" name="You&#39;re more persistant than I thought." feature="Colosseum02" />
+	<key id="COLOSSEUM__AI_ARCANEBLADER_COLOSSEUM__3" name="This is it." feature="Colosseum02" />
+	<key id="COLOSSEUM__AI_ARCANEBLADER_COLOSSEUM__4" name="Can you keep up with me?" feature="Colosseum02" />
+	<key id="COLOSSEUM__AI_ARCANEBLADER_COLOSSEUM__5" name="Only to that extent?" feature="Colosseum02" />
+	<key id="COLOSSEUM__AI_ARCANEBLADER_COLOSSEUM__6" name="Can you keep up with me?" feature="Colosseum02" />
+	<key id="WEDDING_PINATA_IRON_0" name="They said it was going to be a warrior&#39;s wedding,\nbut it&#39;s nothing special!" feature="Wedding" />
+	<key id="WEDDING_PINATA_IRON_1" name="All the sweets are mine!\nDon&#39;t touch that!" feature="Wedding" />
+	<key id="WEDDING_PINATA_IRON_2" name="I&#39;m going to ruin this wedding!" feature="Wedding" />
 </ms2>

--- a/Translated/stringtrigger.xml
+++ b/Translated/stringtrigger.xml
@@ -7432,7 +7432,7 @@
 	<key id="83000003_COLOSSEUM__ROUND11__1" name="So sorry, but you don&apos;t meet the requirements for the next match. Try again later!" npc="MC 나기" type="SideNpcTalk" feature="Colosseum02" />
 	<key id="83000003_COLOSSEUM__ROUND11__2" name="Get ready for the match!" npc="systemMSG" type="ShowCountUI" feature="Colosseum02" />
 	<key id="83000003_COLOSSEUM__ROUND11__3" name="Now I can have a proper match." npc="홀슈타트" type="AddBalloonTalk" feature="Colosseum02" />
-	<key id="83000003_COLOSSEUM__ROUND11__4" name="Argh... Were you this skilled?" npc="홀슈타트" type="AddBalloonTalk" feature="Colosseum02" />
+	<key id="83000003_COLOSSEUM__ROUND11__4" name="Argh... You punk, I can&#39;t believe you were this skilled." npc="홀슈타트" type="AddBalloonTalk" feature="Colosseum02" />
 	<key id="83000003_COLOSSEUM__ROUND11__5" name="Ooh, too bad. Time&apos;s up!" npc="MC 나기" type="SideNpcTalk" feature="Colosseum02" />
 	<key id="83000003_COLOSSEUM__ROUND11__6" name="Oh no, you ran away! This match is over." npc="MC 나기" type="SideNpcTalk" feature="Colosseum02" />
 	<key id="83000003_COLOSSEUM__ROUND11__7" name="You lost. The match is over." npc="systemMSG" type="이벤트UI를설정한다" feature="Colosseum02" />
@@ -7440,7 +7440,7 @@
 	<key id="83000003_COLOSSEUM__ROUND11__9" name="Round 11, Victory!" npc="systemMSG" type="이벤트UI를설정한다" feature="Colosseum02" />
 	<key id="83000003_COLOSSEUM__ROUND11__10" name="Round 11, Defeat..." npc="systemMSG" type="이벤트UI를설정한다" feature="Colosseum02" />
 	<key id="83000003_COLOSSEUM__ROUND11__11" name="What a pity... He was a good-looking bladesman..." npc="퀸크빈" type="SideNpcTalk" feature="Colosseum02" />
-	<key id="83000003_COLOSSEUM__ROUND12__0" name="Isn&apos;t this?! Even after rubbing my eyes... it&apos;s the cute devil, Madria!" npc="MC 나기" type="SideNpcTalk" feature="Colosseum02" />
+	<key id="83000003_COLOSSEUM__ROUND12__0" name="Isn&apos;t this...?! Even after rubbing my eyes... it&apos;s the cute devil, Madria!" npc="MC 나기" type="SideNpcTalk" feature="Colosseum02" />
 	<key id="83000003_COLOSSEUM__ROUND12__1" name="So sorry, but you don&apos;t meet the requirements for the next match. Try again later!" npc="MC 나기" type="SideNpcTalk" feature="Colosseum02" />
 	<key id="83000003_COLOSSEUM__ROUND12__2" name="Get ready for the match!" npc="systemMSG" type="ShowCountUI" feature="Colosseum02" />
 	<key id="83000003_COLOSSEUM__ROUND12__3" name="Hello. We meet again. Let&apos;s have some fun!" npc="마드리아" type="AddBalloonTalk" feature="Colosseum02" />
@@ -7504,143 +7504,143 @@
 	<key id="61000028_ME__61000028_MAIN__4" name="Hide-and-Seek has ended.\nYou&apos;ll be sent back to your previous location." npc="systemMSG" type="ShowCountUI" feature="MassiveHideAndSeek" />
 	<key id="61000028_ME__61000028_MAIN__5" name="There were not enough players to start the game.\nPlease try again later." npc="systemMSG" type="ShowCountUI" feature="MassiveHideAndSeek" />
 	<key id="61000028_ME__61000028_MAIN__6" name="The seeker team is now invincible.\nThey will not lose any lives for attacking non-Hider objects." npc="systemMSG" type="ShowCountUI" feature="MassiveHideAndSeek" />
-	<key id="84000006_WD__84000006_WD_MAIN__0" name="애프터파티에 오신 것을 환영해요!" npc="레인보우 유니콘 피냐타" type="AddBalloonTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__1" name="제 이름은 레인보우 피냐타!" npc="레인보우 유니콘 피냐타" type="AddBalloonTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__2" name="이제 곧 파티를 시작...으윽!" npc="레인보우 유니콘 피냐타" type="AddBalloonTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__3" name="결혼식...\n망친다..." npc="한 맺힌 솔로 악령" type="AddBalloonTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__4" name="다들...\n미워..." npc="한 맺힌 솔로 악령" type="AddBalloonTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__5" name="이런 젠장! 리스항구의 솔로악령이다!" npc="콘대르" type="SideNpcTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__6" name="내 귀여운 피냐타에 스며들다니...!" npc="콘대르" type="SideNpcTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__7" name="저 녀석은 식탐이 매우 강하지." npc="콘대르" type="SideNpcTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__8" name="파티장 음식을 훔쳐 먹으며 악령의 시선을 끌어다오." npc="콘대르" type="SideNpcTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__9" name="그렇게 시간을 벌어주면, 내가 해결책을 찾아내지." npc="콘대르" type="SideNpcTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__10" name="지금부터 음식을 훔쳐 먹으며 시간을 벌자!" npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__11" name="음식들...\n건들지마..." npc="한 맺힌 솔로 악령" type="AddBalloonTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__12" name="자 지금이라네! 무지개 달팽이 공격!" npc="콘대르" type="SideNpcTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__13" name="무지개 달팽이를 던져 악령을 공격하세요!" npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__14" name="오늘도... 혼자야..." npc="한 맺힌 솔로 악령" type="AddBalloonTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__15" name="일단... 물러나지..." npc="한 맺힌 솔로 악령" type="AddBalloonTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__16" name="솔로악령 퇴치 성공!" npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__17" name="어쨌거나 솔로악령을 쫓아냈다!" npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__18" name="구해주셔서 고마워요!\n결혼 축하해요!" npc="레인보우 유니콘 피냐타" type="AddBalloonTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__19" name="오늘도 승리로군!" npc="콘대르" type="AddBalloonTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__20" name="솔로악령 퇴치 성공!" npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__21" name="어쨌거나 솔로악령을 쫓아냈다!" npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__22" name="그래도 구해주셔서 고마워요!\n결혼 축하해요!" npc="레인보우 유니콘 피냐타" type="AddBalloonTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__23" name="오늘도 승리로군!" npc="콘대르" type="AddBalloonTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__24" name="잠시 후 애프터파티가 종료됩니다." npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__25" name="남은 시간,\n친구들과 재밌게 보내세요!" npc="레인보우 유니콘 피냐타" type="AddBalloonTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_MAIN__26" name="자자! 남은 시간\n맘껏 즐기라구!" npc="콘대르" type="AddBalloonTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_WAIT__0" name="까암짝 놀랐지?\n자자, 어서들 오라구!" npc="콘대르" type="AddBalloonTalk" feature="Wedding" />
-	<key id="84000006_WD__84000006_WD_WAIT__1" name="결혼 축하하네!\n벌써 이렇게 크다니." npc="콘대르" type="AddBalloonTalk" feature="Wedding" />
-	<key id="84000007_WD__01_MASSIVEMAIN__0" name="남은 시간동안 애프터파티를 즐겨주세요!\n시간이 지나면 결혼식장으로 이동합니다!" npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
-	<key id="84000007_WD__09_FIREWORKS__0" name="댄스타임은 끝났어~\n하지만 파티는 아직 끝나지 않았어!\n자 불꽃놀이 타임~!" npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
-	<key id="84000007_WD__09_FIREWORKS__1" name="재밌게 플레이 했나요~!\n자 이제 불꽃놀이 타임~!\n결혼 축하해~!" npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
-	<key id="84000011_WD__84000011_MAIN__0" name="두 분, 준비가 다 끝나신 것 같군요.\n그럼 결혼식을 시작해볼까요?" npc="루아나" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000011_WD__84000011_MAIN__1" name="두 사람, 서로 사랑하며 사이좋게 지낼 것을 맹세합니까?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하세요." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000011_WD__84000011_MAIN__2" name="결혼식장에서 나가버리시다니...\n정말 너무해요." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000011_WD__84000011_MAIN__3" name="결혼식은 두 사람이 모두 있어야 진행할 수 있어요.\n일단 진행을 중단하고, 다시 들어오실 때까지 기다려 볼게요." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000011_WD__84000011_MAIN__4" name="이름을 제대로 치셔야지...\n정말 너무해요." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000011_WD__84000011_MAIN__5" name="진정하고 다시 입력해주세요.\n일단 진행을 중단하고, 다시 들어오실 때까지 기다려 볼게요." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000011_WD__84000011_MAIN__6" name="이제 두 사람은 부부가 되었음을 선언합니다." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000012_WD__84000012_MAIN__0" name="두 사람, 준비가 다 끝난 것 같군.\n그럼 결혼식을 시작해볼까?" npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000012_WD__84000012_MAIN__1" name="두 사람, 서로 사랑하며 사이좋게 지낼 것을 맹세합니까?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하게." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000012_WD__84000012_MAIN__2" name="결혼식장에서 나가버리다니...\n 꽤나 무책임한 사람이군 그래." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000012_WD__84000012_MAIN__3" name="결혼식은 두 사람이 모두 있어야 진행할 수 있다네.\n일단 진행을 중단하고, 다시 들어올 때까지 기다려 보도록 하지." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000012_WD__84000012_MAIN__4" name="두 사람...아직 마음이 맞지 않은 것 같군.\n고민중인겐가?" npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000012_WD__84000012_MAIN__5" name="두 사람의 마음이 정해졌다면, 다시 결혼식을 시작해볼까?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하게." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000012_WD__84000012_MAIN__6" name="이제 두 사람은 부부가 되었음을 선언합니다." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000013_WD__84000013_MAIN__0" name="준비가 끝났나 보군.\n이제 식을 시작해 볼까?" npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000013_WD__84000013_MAIN__1" name="두 사람, 서로 사랑하며 사이좋게 지낼 것을 맹세합니까?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하게." npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000013_WD__84000013_MAIN__2" name="저런, 결혼식장에서 나가 버리다니.\n무책임한 사람 같으니라고!" npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000013_WD__84000013_MAIN__3" name="결혼식은 두 사람이 모두 있어야 진행할 수 있네.\n일단 진행을 중단하고, 다시 들어올 때까지 기다려 보겠네." npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000013_WD__84000013_MAIN__4" name="저런, 두 사람의 마음이 아직 통하지 못했나?\n아직도 마음을 정하지 못한 건 아니겠지?" npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000013_WD__84000013_MAIN__5" name="두 사람, 이제 마음을 정했다면 다시 시작해 볼까?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하게." npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000013_WD__84000013_MAIN__6" name="이제 두 사람은 부부가 되었음을 선언합니다." npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000014_WD__84000014_MAIN__0" name="두 사람, 준비가 다 끝난 것 같군요.\n그럼 결혼식을 시작해볼까요?" npc="나메드" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000014_WD__84000014_MAIN__1" name="두 사람, 서로 사랑하며 사이좋게 지낼 것을 맹세합니까?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하세요." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000014_WD__84000014_MAIN__2" name="결혼식장에서 나가버리다니...\n 무례하신 분이군요." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000014_WD__84000014_MAIN__3" name="결혼식은 두 사람이 모두 있어야 진행할 수 있어요.\n일단 진행을 중단하고, 다시 들어오실 때까지 기다려 보도록 하죠." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000014_WD__84000014_MAIN__4" name="두 사람...아직 마음이 맞지 않은 것 같군요.\n고민중인가요?" npc="나메드" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000014_WD__84000014_MAIN__5" name="두 사람의 마음이 정해졌다면, 다시 결혼식을 시작해볼까요?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하세요." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000014_WD__84000014_MAIN__6" name="이제 두 사람은 부부가 되었음을 선언합니다." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000015_WD__84000015_MAIN__0" name="두 분, 준비가 다 끝나신 것 같군요~\n그럼 결혼식을 시작해볼까요?" npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000015_WD__84000015_MAIN__1" name="두 사람, 서로 사랑하며 사이좋게 지낼 것을 맹세합니까?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하세요." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000015_WD__84000015_MAIN__2" name="결혼식장에서 나가버리다니...\n 정말 너무해요." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000015_WD__84000015_MAIN__3" name="결혼식은 두 사람이 모두 있어야 진행할 수 있답니다.\n일단 진행을 중단하고, 다시 들어오실 때까지 기다려 보도록 할게요." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000015_WD__84000015_MAIN__4" name="두 사람...아직 마음이 맞지 않은 것 같아요.\n고민중이신 건가요?" npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000015_WD__84000015_MAIN__5" name="두 분의 마음이 정해졌다면, 다시 결혼식을 시작해볼까요?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하세요." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000015_WD__84000015_MAIN__6" name="이제 두 사람은 부부가 되었음을 선언합니다." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000016_WD__84000016_MAIN__0" name="준비가 끝나셨나 보군요!\n그럼~이제 식을 시작해 볼까요?" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000016_WD__84000016_MAIN__1" name="두 사람, 서로 사랑하며 사이좋게 지낼 것을 맹세합니까?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하세요!" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000016_WD__84000016_MAIN__2" name="저런, 결혼식장에서 나가 버리다니...\n실망했어요!" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000016_WD__84000016_MAIN__3" name="결혼식은 두 사람이 모두 있어야 진행할 수 있답니다.\n일단 진행을 중단하고, 다시 들어올 때까지 기다려 볼게요." npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000016_WD__84000016_MAIN__4" name="저런, 두 사람의 마음이 맞지 않는 건가요?\n아직도 마음을 정하지 못한 건 아니겠죠?" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000016_WD__84000016_MAIN__5" name="두 분, 이제 마음이 정해졌다면 다시 시작해 볼까요?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하세요!" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000016_WD__84000016_MAIN__6" name="이제 두 사람은 부부가 되었음을 선언합니다." npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000021_WD__84000021_MAIN__0" name="두 분, 준비가 다 끝나신 것 같군요.\n그럼 결혼식을 시작해볼까요?" npc="루아나" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000021_WD__84000021_MAIN__1" name="두 사람, 서로 사랑하며 사이좋게 지낼 것을 맹세합니까?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하세요." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000021_WD__84000021_MAIN__2" name="결혼식장에서 나가버리시다니...\n정말 너무해요." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000021_WD__84000021_MAIN__3" name="결혼식은 두 사람이 모두 있어야 진행할 수 있어요.\n일단 진행을 중단하고, 다시 들어오실 때까지 기다려 볼게요." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000021_WD__84000021_MAIN__4" name="이름을 제대로 치셔야지...\n정말 너무해요." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000021_WD__84000021_MAIN__5" name="진정하고 다시 입력해주세요.\n일단 진행을 중단하고, 다시 들어오실 때까지 기다려 볼게요." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000021_WD__84000021_MAIN__6" name="이제 두 사람은 부부가 되었음을 선언합니다." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000022_WD__84000022_MAIN__0" name="두 사람, 준비가 다 끝난 것 같군.\n그럼 결혼식을 시작해볼까?" npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000022_WD__84000022_MAIN__1" name="두 사람, 서로 사랑하며 사이좋게 지낼 것을 맹세합니까?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하게." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000022_WD__84000022_MAIN__2" name="결혼식장에서 나가버리다니...\n 꽤나 무책임한 사람이군 그래." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000022_WD__84000022_MAIN__3" name="결혼식은 두 사람이 모두 있어야 진행할 수 있다네.\n일단 진행을 중단하고, 다시 들어올 때까지 기다려 보도록 하지." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000022_WD__84000022_MAIN__4" name="두 사람...아직 마음이 맞지 않은 것 같군.\n고민중인겐가?" npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000022_WD__84000022_MAIN__5" name="두 사람의 마음이 정해졌다면, 다시 결혼식을 시작해볼까?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하게." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000022_WD__84000022_MAIN__6" name="이제 두 사람은 부부가 되었음을 선언합니다." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000023_WD__84000023_MAIN__0" name="준비가 끝났나 보군.\n이제 식을 시작해 볼까?" npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000023_WD__84000023_MAIN__1" name="두 사람, 서로 사랑하며 사이좋게 지낼 것을 맹세합니까?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하게." npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000023_WD__84000023_MAIN__2" name="저런, 결혼식장에서 나가 버리다니.\n무책임한 사람 같으니라고!" npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000023_WD__84000023_MAIN__3" name="결혼식은 두 사람이 모두 있어야 진행할 수 있네.\n일단 진행을 중단하고, 다시 들어올 때까지 기다려 보겠네." npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000023_WD__84000023_MAIN__4" name="저런, 두 사람의 마음이 아직 통하지 못했나?\n아직도 마음을 정하지 못한 건 아니겠지?" npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000023_WD__84000023_MAIN__5" name="두 사람, 이제 마음을 정했다면 다시 시작해 볼까?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하게." npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000023_WD__84000023_MAIN__6" name="이제 두 사람은 부부가 되었음을 선언합니다." npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000024_WD__84000024_MAIN__0" name="두 사람, 준비가 다 끝난 것 같군요.\n그럼 결혼식을 시작해볼까요?" npc="나메드" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000024_WD__84000024_MAIN__1" name="두 사람, 서로 사랑하며 사이좋게 지낼 것을 맹세합니까?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하세요." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000024_WD__84000024_MAIN__2" name="결혼식장에서 나가버리다니...\n 무례하신 분이군요." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000024_WD__84000024_MAIN__3" name="결혼식은 두 사람이 모두 있어야 진행할 수 있어요.\n일단 진행을 중단하고, 다시 들어오실 때까지 기다려 보도록 하죠." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000024_WD__84000024_MAIN__4" name="두 사람...아직 마음이 맞지 않은 것 같군요.\n고민중인가요?" npc="나메드" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000024_WD__84000024_MAIN__5" name="두 사람의 마음이 정해졌다면, 다시 결혼식을 시작해볼까요?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하세요." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000024_WD__84000024_MAIN__6" name="이제 두 사람은 부부가 되었음을 선언합니다." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000025_WD__84000025_MAIN__0" name="두 분, 준비가 다 끝나신 것 같군요~\n그럼 결혼식을 시작해볼까요?" npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000025_WD__84000025_MAIN__1" name="두 사람, 서로 사랑하며 사이좋게 지낼 것을 맹세합니까?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하세요." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000025_WD__84000025_MAIN__2" name="결혼식장에서 나가버리다니...\n 정말 너무해요." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000025_WD__84000025_MAIN__3" name="결혼식은 두 사람이 모두 있어야 진행할 수 있답니다.\n일단 진행을 중단하고, 다시 들어오실 때까지 기다려 보도록 할게요." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000025_WD__84000025_MAIN__4" name="두 사람...아직 마음이 맞지 않은 것 같아요.\n고민중이신 건가요?" npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000025_WD__84000025_MAIN__5" name="두 분의 마음이 정해졌다면, 다시 결혼식을 시작해볼까요?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하세요." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000025_WD__84000025_MAIN__6" name="이제 두 사람은 부부가 되었음을 선언합니다." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000026_WD__84000026_MAIN__0" name="준비가 끝나셨나 보군요!\n그럼~이제 식을 시작해 볼까요?" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000026_WD__84000026_MAIN__1" name="두 사람, 서로 사랑하며 사이좋게 지낼 것을 맹세합니까?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하세요!" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000026_WD__84000026_MAIN__2" name="저런, 결혼식장에서 나가 버리다니...\n실망했어요!" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000026_WD__84000026_MAIN__3" name="결혼식은 두 사람이 모두 있어야 진행할 수 있답니다.\n일단 진행을 중단하고, 다시 들어올 때까지 기다려 볼게요." npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000026_WD__84000026_MAIN__4" name="저런, 두 사람의 마음이 맞지 않는 건가요?\n아직도 마음을 정하지 못한 건 아니겠죠?" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000026_WD__84000026_MAIN__5" name="두 분, 이제 마음이 정해졌다면 다시 시작해 볼까요?\n맹세한다면 상대방의 이름을 적어 사랑의 서약을 하세요!" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
-	<key id="84000026_WD__84000026_MAIN__6" name="이제 두 사람은 부부가 되었음을 선언합니다." npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__0" name="Welcome to the after-party!" npc="레인보우 유니콘 피냐타" type="AddBalloonTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__1" name="My name is Rainbow Pinata!" npc="레인보우 유니콘 피냐타" type="AddBalloonTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__2" name="The party is starting soon...Argh!" npc="레인보우 유니콘 피냐타" type="AddBalloonTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__3" name="I&#39;m going to ruin...this wedding..." npc="한 맺힌 솔로 악령" type="AddBalloonTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__4" name="I hate... every single one of you..." npc="한 맺힌 솔로 악령" type="AddBalloonTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__5" name="Ah, crap! It&#39;s the evil spirit of Lith Harbor!" npc="콘대르" type="SideNpcTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__6" name="It&#39;s soaking into my cute pinata...!" npc="콘대르" type="SideNpcTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__7" name="That guy has a very strong appetite." npc="콘대르" type="SideNpcTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__8" name="Steal the party food to attract the evil spirit&#39;s attention." npc="콘대르" type="SideNpcTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__9" name="Buy me some time while I find a solution." npc="콘대르" type="SideNpcTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__10" name="Let&#39;s buy some time by stealing food!" npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__11" name="My food... Don&#39;t touch it..." npc="한 맺힌 솔로 악령" type="AddBalloonTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__12" name="Come on now! Rainbow snail attack!" npc="콘대르" type="SideNpcTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__13" name="Toss rainbow snails to attack the evil spirit!" npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__14" name="Today, aswell... I&#39;m alone..." npc="한 맺힌 솔로 악령" type="AddBalloonTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__15" name="First of all... let&#39;s back off..." npc="한 맺힌 솔로 악령" type="AddBalloonTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__16" name="Successfully eradicated the evil spirit!" npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__17" name="Anyway, the evil spirit was cast out!" npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__18" name="Thank you for saving me!\nCongratulations on your wedding!" npc="레인보우 유니콘 피냐타" type="AddBalloonTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__19" name="We won again today!" npc="콘대르" type="AddBalloonTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__20" name="Successfully eradicated the evil spirit!" npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__21" name="Anyway, the evil spirit was cast out!" npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__22" name="Thank you for saving me!\nCongratulations on your wedding!" npc="레인보우 유니콘 피냐타" type="AddBalloonTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__23" name="We won again today!" npc="콘대르" type="AddBalloonTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__24" name="The after-party will end in a moment." npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__25" name="For now, enjoy the rest of your time with your friends!" npc="레인보우 유니콘 피냐타" type="AddBalloonTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_MAIN__26" name="Now! Enjoy the rest of your time!" npc="콘대르" type="AddBalloonTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_WAIT__0" name="You were surprised, right? Come on, come on!" npc="콘대르" type="AddBalloonTalk" feature="Wedding" />
+	<key id="84000006_WD__84000006_WD_WAIT__1" name="Congratulations on your wedding! I can&#39;t believe it&#39;s already this big." npc="콘대르" type="AddBalloonTalk" feature="Wedding" />
+	<key id="84000007_WD__01_MASSIVEMAIN__0" name="Please enjoy the after-party for the rest of the time!\nAfter the time is up, we will move to the wedding hall!" npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
+	<key id="84000007_WD__09_FIREWORKS__0" name="Dance time is over~\nBut the party is not over yet!\nFireworks time~!" npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
+	<key id="84000007_WD__09_FIREWORKS__1" name="Hope you had fun playing~!\nIt&#39;s firework time now~!\nCongratulations on your wedding~!" npc="systemMSG" type="이벤트UI를설정한다" feature="Wedding" />
+	<key id="84000011_WD__84000011_MAIN__0" name="You two, it looks like everything is ready.\nThen, shall we start the wedding?" npc="루아나" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000011_WD__84000011_MAIN__1" name="Do you two swear to love each other and to get along?\nIf you swear, write each other&#39;s name and make a vow of love." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000011_WD__84000011_MAIN__2" name="You&#39;re leaving mid-wedding...\nYou are too much." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000011_WD__84000011_MAIN__3" name="The wedding can take place only when both people are present.\nI&#39;ll stop the ceremony for now and wait until you come back." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000011_WD__84000011_MAIN__4" name="You have to write the name correctly...\nYou are too much." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000011_WD__84000011_MAIN__5" name="Please calm down and try again.\nI&#39;ll stop the process for now and wait for you." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000011_WD__84000011_MAIN__6" name="I now declare the two married." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000012_WD__84000012_MAIN__0" name="You two, it looks like everything is ready.\nThen, shall we start the wedding?" npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000012_WD__84000012_MAIN__1" name="Do you two swear to love each other and to get along?\nIf you swear, write each other&#39;s name and make a vow of love." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000012_WD__84000012_MAIN__2" name="Leaving the wedding hall...\nYou&#39;re a pretty irresponsible person." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000012_WD__84000012_MAIN__3" name="The wedding can take place only when both people are present.\nLet&#39;s stop the ceremony and wait until they come back." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000012_WD__84000012_MAIN__4" name="The two of them... I don&#39;t think they&#39;re in sync yet.\nAre you having second thoughts?" npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000012_WD__84000012_MAIN__5" name="If the two of you have made up your mind, shall we start the wedding again?\nIf you swear, write each other&#39;s name and make a vow of love." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000012_WD__84000012_MAIN__6" name="I now declare the two married." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000013_WD__84000013_MAIN__0" name="Looks like you&#39;re ready.\nShall we start the ceremony now?" npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000013_WD__84000013_MAIN__1" name="Do you two swear to love each other and to get along?\nIf you swear, write each other&#39;s name and make a vow of love." npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000013_WD__84000013_MAIN__2" name="Oh my, I can&#39;t believe you left the wedding hall.\nWhat an irresponsible person!" npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000013_WD__84000013_MAIN__3" name="The wedding can only take place with both of you present.\nI&#39;ll stop the ceremony for now and wait until they come back." npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000013_WD__84000013_MAIN__4" name="Oh my, do your hearts not feel the same?\nHave you not made up your mind yet?" npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000013_WD__84000013_MAIN__5" name="The two of you, now that you have made up your mind, shall we start over?\nIf you swear, write each other&#39;s name and make a vow of love." npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000013_WD__84000013_MAIN__6" name="I now declare the two married." npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000014_WD__84000014_MAIN__0" name="The two of you, it looks like everything is ready.\nSo, shall we start the ceremony?" npc="나메드" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000014_WD__84000014_MAIN__1" name="Do you two swear to love each other and to get along?\nIf you swear, write each other&#39;s name and make a vow of love." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000014_WD__84000014_MAIN__2" name="Leaving the wedding hall...\n You are so rude." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000014_WD__84000014_MAIN__3" name="A wedding can only take place when both people are present.\nLet&#39;s stop the ceremony and wait until you come back." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000014_WD__84000014_MAIN__4" name="It looks like the two of you haven&#39;t gotten along yet.\nAre you worried?" npc="나메드" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000014_WD__84000014_MAIN__5" name="If the two of them have made up their minds, shall we start the wedding again?\nIf you swear, write each other&#39;s name and make a vow of love." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000014_WD__84000014_MAIN__6" name="I now declare the two married." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000015_WD__84000015_MAIN__0" name="The two of you, it looks like you&#39;re all set~\nSo, shall we start the wedding?" npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000015_WD__84000015_MAIN__1" name="Do you two swear to love each other and to get along?\nIf you swear, write each other&#39;s name and make a vow of love." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000015_WD__84000015_MAIN__2" name="Leaving the wedding hall...\n Unbelievable." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000015_WD__84000015_MAIN__3" name="A wedding can only take place when both of them are present.\nI&#39;ll stop the ceremony and wait until you come back." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000015_WD__84000015_MAIN__4" name="The two of you... it doesn&#39;t look like you&#39;re synched.\nAre you worried?" npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000015_WD__84000015_MAIN__5" name="If the two of you have made up your minds, shall we start the wedding again?\nIf you swear, write each other&#39;s name and make a vow of love." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000015_WD__84000015_MAIN__6" name="I now declare the two married." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000016_WD__84000016_MAIN__0" name="Looks like you&#39;re ready!\nSo~, let&#39;s start the ceremony, shall we?" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000016_WD__84000016_MAIN__1" name="Do you two swear to love each other and to get along?\nIf you swear, write each other&#39;s name and make a vow of love!" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000016_WD__84000016_MAIN__2" name="Damn, you&#39;re leaving the wedding hall...\nDisappointing!" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000016_WD__84000016_MAIN__3" name="The wedding can only be held with both of them present.\nI&#39;ll stop the ceremony and wait until they come back." npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000016_WD__84000016_MAIN__4" name="Oh my, don&#39;t the two of you agree?\nYou haven&#39;t made up your mind yet, have you?" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000016_WD__84000016_MAIN__5" name="You two, now that you have made up your mind, shall we start again?\nIf you swear, write each other&#39;s name and make a vow of love!" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000016_WD__84000016_MAIN__6" name="I now declare the two married." npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000021_WD__84000021_MAIN__0" name="You two, it looks like everything is ready.\nThen, shall we start the wedding?" npc="루아나" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000021_WD__84000021_MAIN__1" name="Do you two swear to love each other and to get along?\nIf you swear, write each other&#39;s name and make a vow of love." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000021_WD__84000021_MAIN__2" name="You&#39;re leaving mid-wedding...\nYou are too much." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000021_WD__84000021_MAIN__3" name="The wedding can take place only when both people are present.\nI&#39;ll stop the ceremony for now and wait until you come back." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000021_WD__84000021_MAIN__4" name="You have to write the name correctly...\nYou are too much." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000021_WD__84000021_MAIN__5" name="Please calm down and try again.\nI&#39;ll stop the process for now and wait for you." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000021_WD__84000021_MAIN__6" name="I now declare the two married." npc="루아나" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000022_WD__84000022_MAIN__0" name="You two, it looks like everything is ready.\nThen, shall we start the wedding?" npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000022_WD__84000022_MAIN__1" name="Do you two swear to love each other and to get along?\nIf you swear, write each other&#39;s name and make a vow of love." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000022_WD__84000022_MAIN__2" name="Leaving the wedding hall...\nYou&#39;re a pretty irresponsible person." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000022_WD__84000022_MAIN__3" name="The wedding can take place only when both people are present.\nLet&#39;s stop the ceremony and wait until they come back." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000022_WD__84000022_MAIN__4" name="The two of them... I don&#39;t think they&#39;re in sync yet.\nAre you having second thoughts?" npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000022_WD__84000022_MAIN__5" name="If the two of you have made up your mind, shall we start the wedding again?\nIf you swear, write each other&#39;s name and make a vow of love." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000022_WD__84000022_MAIN__6" name="I now declare the two married." npc="마노비치" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000023_WD__84000023_MAIN__0" name="Looks like you&#39;re ready.\nShall we start the ceremony now?" npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000023_WD__84000023_MAIN__1" name="Do you two swear to love each other and to get along?\nIf you swear, write each other&#39;s name and make a vow of love." npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000023_WD__84000023_MAIN__2" name="Oh my, I can&#39;t believe you left the wedding hall.\nWhat an irresponsible person!" npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000023_WD__84000023_MAIN__3" name="The wedding can only take place with both of you present.\nI&#39;ll stop the ceremony for now and wait until they come back." npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000023_WD__84000023_MAIN__4" name="Oh my, do your hearts not feel the same?\nHave you not made up your mind yet?" npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000023_WD__84000023_MAIN__5" name="The two of you, now that you have made up your mind, shall we start over?\nIf you swear, write each other&#39;s name and make a vow of love." npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000023_WD__84000023_MAIN__6" name="I now declare the two married." npc="아시모프" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000024_WD__84000024_MAIN__0" name="The two of you, it looks like everything is ready.\nSo, shall we start the ceremony?" npc="나메드" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000024_WD__84000024_MAIN__1" name="Do you two swear to love each other and to get along?\nIf you swear, write each other&#39;s name and make a vow of love." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000024_WD__84000024_MAIN__2" name="Leaving the wedding hall...\n You are so rude." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000024_WD__84000024_MAIN__3" name="A wedding can only take place when both people are present.\nLet&#39;s stop the ceremony and wait until you come back." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000024_WD__84000024_MAIN__4" name="It looks like the two of you haven&#39;t gotten along yet.\nAre you worried?" npc="나메드" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000024_WD__84000024_MAIN__5" name="If the two of them have made up their minds, shall we start the wedding again?\nIf you swear, write each other&#39;s name and make a vow of love." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000024_WD__84000024_MAIN__6" name="I now declare the two married." npc="나메드" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000025_WD__84000025_MAIN__0" name="The two of you, it looks like you&#39;re all set~\nSo, shall we start the wedding?" npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000025_WD__84000025_MAIN__1" name="Do you two swear to love each other and to get along?\nIf you swear, write each other&#39;s name and make a vow of love." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000025_WD__84000025_MAIN__2" name="Leaving the wedding hall...\nUnbelievable." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000025_WD__84000025_MAIN__3" name="A wedding can only take place when both of them are present.\nI&#39;ll stop the ceremony and wait until you come back." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000025_WD__84000025_MAIN__4" name="The two of you... it doesn&#39;t look like you&#39;re synched.\nAre you worried?" npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000025_WD__84000025_MAIN__5" name="If the two of you have made up your minds, shall we start the wedding again?\nIf you swear, write each other&#39;s name and make a vow of love." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000025_WD__84000025_MAIN__6" name="I now declare the two married." npc="클로리스" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000026_WD__84000026_MAIN__0" name="Looks like you&#39;re ready!\nSo~, let&#39;s start the ceremony, shall we?" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000026_WD__84000026_MAIN__1" name="Do you two swear to love each other and to get along?\nIf you swear, write each other&#39;s name and make a vow of love" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000026_WD__84000026_MAIN__2" name="Damn, you&#39;re leaving the wedding hall...\nDisappointing!" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000026_WD__84000026_MAIN__3" name="The wedding can only be held with both of them present.\nI&#39;ll stop the ceremony and wait until they come back." npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000026_WD__84000026_MAIN__4" name="Oh my, don&#39;t the two of you agree?\nYou haven&#39;t made up your mind yet, have you?" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000026_WD__84000026_MAIN__5" name="You two, now that you have made up your mind, shall we start again?\nIf you swear, write each other&#39;s name and make a vow of love!" npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
+	<key id="84000026_WD__84000026_MAIN__6" name="I now declare the two married." npc="데이데이" type="AddCinematicTalk" feature="Wedding" />
 	<key id="52000188_QD__52000188__0" name="What&apos;s this...?" npc="player" type="AddCinematicTalk" feature="JobChange_02" />
-	<key id="52000191_QD__52000191__0" name="바론의 감옥" npc="systemMSG" type="ShowCaption" feature="EpicApocalypse01" />
-	<key id="52000191_QD__52000191__1" name="당신이 바론이군요…과거 칠영웅이었던." npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
-	<key id="52000191_QD__52000191__2" name="네놈은 누구지?\n처음 보는 애송이로군." npc="바론" type="AddCinematicTalk" feature="EpicApocalypse01" />
-	<key id="52000191_QD__52000191__3" name="어둠의 물질이 당신의 짓이라고 들었어요.\n왜 이런 짓을 하는 거죠?" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
-	<key id="52000191_QD__52000191__4" name="어둠의 물질? \n…킬리안이 연구하던 그 물질을 말하는 건가?" npc="바론" type="AddCinematicTalk" feature="EpicApocalypse01" />
-	<key id="52000191_QD__52000191__5" name="시치미떼지 마시죠.\n더 이상의 음모는 그만두세요. 칼에게 모든 걸 들었으니!\n그렇지 않으면 당신을 처치하겠습니다." npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
-	<key id="52000191_QD__52000191__6" name="…이젠 나를 없애려고까지 하는군, 칼." npc="바론" type="AddCinematicTalk" feature="EpicApocalypse01" />
-	<key id="52000191_QD__52000191__7" name="킬리안은 결국 실패한 건가?\n지금 메이플 월드는 도대체 어떻게 된 거냐!" npc="바론" type="AddCinematicTalk" feature="EpicApocalypse01" />
-	<key id="52000191_QD__52000191__8" name="무슨 소릴 하는지 알 수가 없군요.\n트라이아에 어둠을 흩뿌리는 짓을 당장 그만두란 말이야!" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
-	<key id="52000191_QD__52000191__9" name="…흥. \n말 안 듣는 애송이는 매가 약인가." npc="바론" type="AddCinematicTalk" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__0" name="Balon&#39;s Prison" npc="systemMSG" type="ShowCaption" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__1" name="You&#39;re Balon... one of the former Seven Heroes." npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__2" name="Who are you? I&#39;ve never seen you before, newbie." npc="바론" type="AddCinematicTalk" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__3" name="I&#39;ve heard that the dark matter is your work. Why are you doing this?" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__4" name="Dark matter? Are you referring to the substance that Cerian was studying?" npc="바론" type="AddCinematicTalk" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__5" name="Don&#39;t mess with me.\nI&#39;ve heard everything from Karl! Stop scheming.\nOtherwise I will kill you." npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__6" name="...Now you&#39;re even trying to get rid of me, Karl." npc="바론" type="AddCinematicTalk" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__7" name="Did Cerian ultimately fail?\n What the hell is happening to Maple World right now!" npc="바론" type="AddCinematicTalk" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__8" name="I don&#39;t know what you&#39;re talking about.\nStop scattering the darkness in Tria right now!" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__9" name="…Hmph.\nMaybe this will teach you to listen, brat." npc="바론" type="AddCinematicTalk" feature="EpicApocalypse01" />
 	<key id="52000191_QD__52000191__10" name="그동안의 일을 순순히 불게 해주지." npc="바론" type="AddCinematicTalk" feature="EpicApocalypse01" />
-	<key id="52000191_QD__52000191__11" name="흥, 생각보다 끈질기군." npc="바론" type="SideNpcTalk" feature="EpicApocalypse01" />
-	<key id="52000191_QD__52000191__12" name="이 애송이…뭐지?" npc="바론" type="SideNpcTalk" feature="EpicApocalypse01" />
-	<key id="52000191_QD__52000191__13" name="네 녀석, 뭔가 이상하군…." npc="바론" type="SideNpcTalk" feature="EpicApocalypse01" />
-	<key id="52000191_QD__52000191__14" name="…!!!" npc="바론" type="SideNpcTalk" feature="EpicApocalypse01" />
-	<key id="52000191_QD__52000191__15" name="헉…헉…" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
-	<key id="52000191_QD__52000191__16" name="……." npc="바론" type="AddCinematicTalk" feature="EpicApocalypse01" />
-	<key id="52000191_QD__52000191__17" name="(잠깐…뭔가 이상해. 칼에게는 분명 바론이 어둠에 물들었다고 들었는데…)" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
-	<key id="52000191_QD__52000191__18" name="(지금 바론에게서 느껴지는 이 힘은…어둠이 아니라 마치, 신성한 것처럼 느껴지잖아.)" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
-	<key id="52000191_QD__52000191__19" name="(뭔가 이상하군. 이 애송이…)" npc="바론" type="AddCinematicTalk" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__11" name="Huh, you&#39;re more persistant than I thought." npc="바론" type="SideNpcTalk" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__12" name="This punk...what?" npc="바론" type="SideNpcTalk" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__13" name="Fella, something is strange in you..." npc="바론" type="SideNpcTalk" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__14" name="...!!!" npc="바론" type="SideNpcTalk" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__15" name="Ugh... Ugh..." npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__16" name="......" npc="바론" type="AddCinematicTalk" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__17" name="(Wait…something&#39;s strange. I&#39;ve heard from Karl that Balon is tainted with darkness…)" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__18" name="(This power I feel coming from Balon right now... It&#39;s not darkness, it feels like it&#39;s holy.)" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
+	<key id="52000191_QD__52000191__19" name="(Something is wrong. This rookie...)" npc="바론" type="AddCinematicTalk" feature="EpicApocalypse01" />
 	<key id="52000191_QD__52000191__20" name="(한없이 정의로운 영혼을 가지고 있어.)" npc="바론" type="AddCinematicTalk" feature="EpicApocalypse01" />
 	<key id="52000192_QD__52000192__0" name="뜨거운 열기가…!" npc="에레브" type="AddCinematicTalk" feature="EpicApocalypse01" />
 	<key id="52000192_QD__52000192__1" name="이런…이곳도 벌써 불바다에요." npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
@@ -7738,23 +7738,23 @@
 	<key id="52000202_QD__52000202__5" name="뭔가 강력한 기운이…!" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
 	<key id="52000202_QD__52000202__6" name="뭐지?!" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
 	<key id="52000202_QD__52000202__7" name="?! 저녀석들은…!" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
-	<key id="52000202_QD__52000202__8" name="과거에 내가 처치했던 녀석들이잖아.\n왜 여기에…?" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
-	<key id="52000202_QD__52000202__9" name="크윽, 가까워진다.\n일단 해치우는 게 좋겠어!" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
+	<key id="52000202_QD__52000202__8" name="These are the guys I&#39;ve slain in the past. Why are you here...?" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
+	<key id="52000202_QD__52000202__9" name="Ugh, it&#39;s getting closer.\nI&#39;d better get rid of it first!" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
 	<key id="52000202_QD__52000202__10" name="...?" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
-	<key id="52000202_QD__52000202__11" name="전부...사라졌잖아?" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
+	<key id="52000202_QD__52000202__11" name="Everything... disappeared?" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
 	<key id="52000202_QD__52000202__12" name="대체 뭐였던거지?" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
-	<key id="52000202_QD__52000202__13" name="윽, 시공간이 다시 불안정해지고있어." npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
+	<key id="52000202_QD__52000202__13" name="Ugh, space and time are becoming unstable again." npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
 	<key id="52000202_QD__52000202__14" name="일단 어서 밖으로...!" npc="player" type="AddCinematicTalk" feature="EpicApocalypse01" />
-	<key id="52000199_QD__52000199__0" name="검은달 심연" npc="systemMSG" type="ShowCaption" feature="EpicApocalypse01" />
-	<key id="52000199_QD__52000199_2__0" name="킬리안이 모든 진실을 말하고 난 뒤…" npc="systemMSG" type="연출UI를설정한다" feature="EpicApocalypse01" />
-	<key id="51000006_DG__51000006_MAIN__0" name="안녕! 난 자유로운 블랙빈! 노는 게 제일 좋아!\n지금부터 나랑 놀자!" npc="systemMSG" type="연출UI를설정한다" feature="Event" />
-	<key id="51000006_DG__51000006_MAIN__1" name="나와 다른 방향을 선택하면 네가 이기고, \n같은 방향을 선택하면 지는 거야~!" npc="systemMSG" type="연출UI를설정한다" feature="Event" />
-	<key id="51000006_DG__51000006_MAIN__2" name="네가 다섯 번 지면 놀이는 끝!\n오래 버틸수록 높은 점수를 받지!" npc="systemMSG" type="연출UI를설정한다" feature="Event" />
-	<key id="51000006_DG__51000006_MAIN__3" name="순위가 높으면 선물도 주지! 어때, 끌리지?\n그럼 바로 시작해 보자~ 뿡뿡!" npc="systemMSG" type="연출UI를설정한다" feature="Event" />
+	<key id="52000199_QD__52000199__0" name="Black Moon Abyss" npc="systemMSG" type="ShowCaption" feature="EpicApocalypse01" />
+	<key id="52000199_QD__52000199_2__0" name="After Cerian told the whole truth..." npc="systemMSG" type="연출UI를설정한다" feature="EpicApocalypse01" />
+	<key id="51000006_DG__51000006_MAIN__0" name="Hi! I&#39;m the free-spirited Black Bean! Playing is the best!\nPlay with me from now on!" npc="systemMSG" type="연출UI를설정한다" feature="Event" />
+	<key id="51000006_DG__51000006_MAIN__1" name="If you choose a different direction than me, you win;\nif you choose the same direction, you lose!" npc="systemMSG" type="연출UI를설정한다" feature="Event" />
+	<key id="51000006_DG__51000006_MAIN__2" name="If you lose five times, it&#39;s game over! The longer you go, the higher you score!" npc="systemMSG" type="연출UI를설정한다" feature="Event" />
+	<key id="51000006_DG__51000006_MAIN__3" name="If you rank high enough, you&#39;ll get a gift! Pretty good deal, huh?\nThen let&#39;s begin~ Boing-boing!" npc="systemMSG" type="연출UI를설정한다" feature="Event" />
 	<key id="51000006_DG__51000006_MAIN__4" name="너한텐 안 져!" npc="NotUse" type="AddBalloonTalk" feature="Event" />
-	<key id="51000006_DG__51000006_MAIN__5" name="빙글빙글~!" npc="시간여행자 블랙빈" type="AddBalloonTalk" feature="Event" />
-	<key id="51000006_DG__51000006_MAIN__6" name="내가 졌잖아?!" npc="시간여행자 블랙빈" type="AddBalloonTalk" feature="Event" />
-	<key id="51000006_DG__51000006_MAIN__7" name="내가 이겼지롱!" npc="player" type="AddBalloonTalk" feature="Event" />
-	<key id="51000006_DG__51000006_MAIN__8" name="얼레리꼴레리~ 졌대요~ 메롱!" npc="시간여행자 블랙빈" type="AddBalloonTalk" feature="Event" />
-	<key id="51000006_DG__51000006_MAIN__9" name="으악! 분해!" npc="player" type="AddBalloonTalk" feature="Event" />
+	<key id="51000006_DG__51000006_MAIN__5" name="Round and round~!" npc="시간여행자 블랙빈" type="AddBalloonTalk" feature="Event" />
+	<key id="51000006_DG__51000006_MAIN__6" name="Did I just lose?!" npc="시간여행자 블랙빈" type="AddBalloonTalk" feature="Event" />
+	<key id="51000006_DG__51000006_MAIN__7" name="I won!" npc="player" type="AddBalloonTalk" feature="Event" />
+	<key id="51000006_DG__51000006_MAIN__8" name="Ne-ne ne-ne ne~ You lost~ Pbbblt!" npc="시간여행자 블랙빈" type="AddBalloonTalk" feature="Event" />
+	<key id="51000006_DG__51000006_MAIN__9" name="Ugh! Damn it!" npc="player" type="AddBalloonTalk" feature="Event" />
 </ms2>

--- a/Translated/usmsubtitletext.xml
+++ b/Translated/usmsubtitletext.xml
@@ -150,44 +150,44 @@
 	<key id="Lapenta_Frontier_Intro_caption14" name="Even when you have no voice,\nI&apos;ll hear your cry" feature="LapentaFrontierQuest" />
 	<key id="Lapenta_Frontier_Intro_caption15" name="Dry your eyes,\n&apos;cause I&apos;ll" feature="LapentaFrontierQuest" />
 	<key id="Lapenta_Frontier_Intro_caption16" name="Hold you tight" feature="LapentaFrontierQuest" />
-	<key id="KiliansTruth_caption1" name="사라졌던 영웅의 등장에 놀랐는가?" feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption2" name="그렇다. 내가 바로 빛의 마법사 킬리안이다." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption3" name="그리고 또 다른 이름" feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption4" name="검은 마법사." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption5" name="놀라는 것도 무리는 아니지." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption6" name="한때 7영웅의 수장이 바로 나였으니." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption7" name="이제 그날의 진실을 말할 때가 된 것 같구나." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption8" name="나는 라펜타 봉인을 위해" feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption9" name="7영웅 중 하나이자 나의 친우인 바론과 함께\n 어둠의 땅으로 향했다." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption10" name="그리고, 그곳에 도달한 우리는 깨달았지." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption11" name="봉인을 위해선 여제 에레브의 힘이 필요하다는 것을." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption12" name="이를 알리기 위해 바론은 트라이아로 향했다." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption13" name="나는 그곳에 남아 상황을 지켜보았지만" feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption14" name="생각보다 빠르게 악화되는 봉인의 상태에\n결단을 내려야만 했다." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption15" name="혼자서라도 봉인을 시도해야 했어." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption16" name="내 목숨과 바꿔서라도 말이야." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption17" name="다행히 난 봉인에 성공했지만 정신이 혼미해지고 있었다." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption18" name="그리고 돌연, 바론의 기운이 끊어졌다!" feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption19" name="나는, 처음으로 여제를 의심했다." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption20" name="여제가 늦는 것이 아니라 \n우리 요청이 묵살당한 거라면?" feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption21" name="빛의 상징인 여제가 우릴 버렸다면…?" feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption22" name="그 순간, 나는 보았다." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption23" name="빛의 여제가 가진 강력한 힘이 이 세상을 멸망시키는 모습을." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption24" name="빛의 창 끝이 어둠이 아닌 우리를 향하는 날" feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption25" name="우리가 맞게 될 빛으로부터의 파멸을…" feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption26" name="그날 이후 나는 여제의 파멸을 막기 위해 여러 계획을 세우고 실행해왔다." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption27" name="그 중 가장 심혈을 기울여 준비한 것이 바로 이, 검은 달이다. " feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption28" name="여제 에레브… 그녀는 이곳에 봉인되어야 해." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption29" name="최근 트라이아에 나타난 검은 물질들을 보았겠지?" feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption30" name="그건 바로, 여제 안에 잠들어 있던 불안의 미래가 형상화되어 나타난 것." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption31" name="언젠가 다가올 파멸의 증거다! " feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption32" name="빛으로부터의 파멸" feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption33" name="그 예언을 막기 위한 방법은 오직 이것 뿐이다." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption34" name="과거의 영웅은 죽었다." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption35" name="내게 남은 것은 오직 세상의 파괴를 막기 위한 간절한 소망 뿐." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption36" name="예언을 아는 자라면, 이 진실을 외면할 수 없을 것이다." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption37" name="애송이, 이제 너도 모든 것을 알게 되었고… " feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption38" name="선택만이 남았다." feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption39" name="진실과 거짓" feature="EpicApocalypse01" />
-	<key id="KiliansTruth_caption40" name="선택하라" feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption1" name="Were you surprised by the reappearance of the missing hero?" feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption2" name="Yes. I am Cerian, the Mage of Light." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption3" name="Also known by another name." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption4" name="The Black Mage." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption5" name="It is not unreasonable to be surprised." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption6" name="I was once the leader of the Seven Heroes." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption7" name="I think it&#39;s time to tell you the truth of that day." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption8" name="To seal the lapenta," feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption9" name="I headed to the land of darkness with Balon,\none of the seven heroes and my best friend." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption10" name="But when we arrived, we realized..." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption11" name="that we required empress Ereve&#39;s power to seal it." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption12" name="Balon headed to Tria to request her aid," feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption13" name="while I stayed there and watched over the situation." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption14" name="I had to make a decision on the state of the seal,\nwhich was deteriorating faster than expected." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption15" name="I had to try sealing it, even if by myself." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption16" name="Even if it meant exchanging my life." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption17" name="Fortunately, I succeeded in sealing it, but I was losing my mind." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption18" name="And suddenly, I could no longer sense Balon&#39;s energy!" feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption19" name="I, for the first time, doubted the Empress." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption20" name="What if it&#39;s not that she is late,\nbut instead our request got ignored?" feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption21" name="What if the empress, the symbol of light, had abandoned us...?" feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption22" name="At that moment, I saw it." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption23" name="An image of the mighty power of the Empress of light, destroying this world." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption24" name="The day when the end of the window of light is facing us," feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption25" name="We will greeted by destruction, not by darkness, but by light..." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption26" name="Since that day, I have made and implemented various plans\nto prevent the empress&#39;s destruction" feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption27" name="Among them, the Black Moon is the one that I prepared with the utmost care." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption28" name="Empress Ereve... she must be sealed here." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption29" name="You&#39;ve seen the dark matter that recently materialised in Tria, right?" feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption30" name="That&#39;s right, the Empress was asleep in the stark imagery of the future shown to me." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption31" name="It&#39;s proof of the destruction that is to come!" feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption32" name="Destruction by light." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption33" name="This is the only way to stop the prophecy from fulfilling." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption34" name="The hero of the past is dead." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption35" name="All I have left is this earnest desire, desperate hope,\nof stopping the destruction of this world." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption36" name="Anyone who knows the prophecy will not be able to turn a blind eye to this truth." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption37" name="Child, now that you know the truth..." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption38" name="Only one decision remains." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption39" name="Truth or lies." feature="EpicApocalypse01" />
+	<key id="KiliansTruth_caption40" name="Choose." feature="EpicApocalypse01" />
 </ms2>


### PR DESCRIPTION
jobname.xml:
>Job ID 10 is now properly named Beginner instead of Knight.

stringnpcai.xml:
>Translated the strings for all dialogs triggered by Archeon, Miel, Holstatt and Wedding Piñata's AIs.

stringtrigger.xml:
>Translated all wedding trigger strings.
>Translated part of the Balon prison encounter and EpicApocalypse01 conclusion trigger strings.
>Translated all Black Bean arcade trigger strings.

npcname.xml:
>Translated all remaining untranslated EpicApocalypse01-02 strings.
>Replaced certain placeholder Kritias_Epic02 strings with their finalized names.
>Fixed wedding host DayDay's name, changing it from Dede.

usmsubtitletext.xml:
>Translated the subtitles for the Cerian's Truth cutscene.

how to github