### PR TITLE
Beginner event patch

### DIFF
--- a/Translated/scriptnpc.xml
+++ b/Translated/scriptnpc.xml
@@ -8507,36 +8507,36 @@
 	<key id="831180407001652" npc="오두막 할아범" name="You&apos;re being very attentive. I&apos;m glad I&apos;m not boring you. Is there anything else you want to hear?" />
 	<key id="831180407001653" npc="pc" name="Actually, I&apos;d better be on my way." />
 	<key id="831180407001654" npc="pc" name="Tell me another old story." />
-	<key id="831180407001655" npc="pc" name="Tell me about what&apos;s going on now." />
-	<key id="831180407001656" npc="오두막 할아범" name="I didn&apos;t know it was getting so late. The forest trail has been fraught with mushrooms and pigs. Please be safe." />
+	<key id="831180407001655" npc="pc" name="Tell me about Maple World." />
+	<key id="831180407001656" npc="오두막 할아범" name="It has gotten late. I hope you didn&#39;t have too much of a hard time listening to this old man.&#x0A;I hope it will help you on your adventure.&#x0A;Mushrooms and pigs are running rampant on the trail these days, so be careful. I wish you a good adventure." />
 	<key id="831180407001657" npc="오두막 할아범" name="Another old story? What kind of story?" />
 	<key id="831180407001658" npc="pc" name="Tell me about the sages and the Lapenta." />
-	<key id="831180407001659" npc="pc" name="Tell me about $npcName:11000075[gender:1]$ and the heroes." />
+	<key id="831180407001659" npc="pc" name="Tell me about $npcName:11000075[gender:1]$ and the Seven Heroes." />
 	<key id="831180407001661" npc="pc" name="I&apos;m not that interested in old stories, honestly." />
-	<key id="831180407001662" npc="오두막 할아범" name="This world wouldn&apos;t have existed if it weren&apos;t for the sages and the Lapenta. Which story do you want to hear first?" />
+	<key id="831180407001662" npc="오두막 할아범" name="This world wouldn&apos;t have existed if it weren&apos;t for the sages and the Lapentas. Which story do you want to hear first?" />
 	<key id="831180407001663" npc="pc" name="Let&apos;s hear about the sages." />
-	<key id="831180407001664" npc="pc" name="I&apos;m interested in the Lapenta." />
+	<key id="831180407001664" npc="pc" name="I&apos;m interested in the Lapentas." />
 	<key id="831180407001665" npc="pc" name="How about a different old story?" />
-	<key id="831180407001666" npc="오두막 할아범" name="Originally, each of the three sages was responsible for one aspect of the world. They governed life, space, and time to ensure the world remained in balance. Then one day…" />
-	<key id="831180407001667" npc="오두막 할아범" name="The Demon King emerged, intent on destroying the balance between the three fundamental powers. He wanted to overtake the world with his own dark powers, turning it to a realm of endless chaos and despair." />
-	<key id="831180407001668" npc="오두막 할아범" name="The Demon King was strong enough to match the combined powers of the sages. To defeat him, the sages were forced to sacrifice themselves to banish the Demon King. Their legacy lives on in the Lapentas which contain what&apos;s left of their powers. Now do you understand why the sages were so important?" />
+	<key id="831180407001666" npc="오두막 할아범" name="In the ancient times, the three &lt;font color=&quot;#ffd200&quot;&gt;sages&lt;/font&gt; were responsible coordinating the balance and order of the world in the behalf of the Goddesses, with power of &lt;font color=&quot;#ffd200&quot;&gt;life&lt;/font&gt;, &lt;font color=&quot;#ffd200&quot;&gt;space&lt;/font&gt; and &lt;font color=&quot;#ffd200&quot;&gt;time&lt;/font&gt;.&#x0A;Then one day..." />
+	<key id="831180407001667" npc="오두막 할아범" name="As &lt;font color=&quot;#ffd200&quot;&gt;darkness/font&gt; enveloped the light, the world fell into chaos and despair.&#x0A;The &lt;font color=&quot;#ffd200&quot;&gt;sages&lt;/font&gt; created the lapentas of &lt;font color=&quot;#ffd200&quot;&gt;life&lt;/font&gt;, &lt;font color=&quot;#ffd200&quot;&gt;space&lt;/font&gt; and &lt;font color=&quot;#ffd200&quot;&gt;time&lt;/font&gt; with a strong power to seal the &lt;font color=&quot;#ffd200&quot;&gt;darkness&lt;/font&gt;." />
+	<key id="831180407001668" npc="오두막 할아범" name="However, after exhausting all their power to make the &lt;font color=&quot;#ffd200&quot;&gt;Lapentas&lt;/font&gt;, they were swallowed up by &lt;font color=&quot;#ffd200&quot;&gt;darkness&lt;/font&gt;.&#x0A;How is it? Did I satiate your curiosity?" />
 	<key id="831180407001669" npc="pc" name="Yep!" />
-	<key id="831180407001670" npc="오두막 할아범" name="The Lapentas were created by the sages to protect this world from the Demon King. They gave their lives to grant us these powerful gifts." />
-	<key id="831180407001671" npc="오두막 할아범" name="The Green Lapenta  keeps the balance of life, the Blue Lapenta governs space, and the Red Lapenta maintains time." />
-	<key id="831180407001672" npc="오두막 할아범" name="These three Lapentas have formed a protective ward around this world, keeping the formidable Demon King and his dark power at bay. Hopefully that explains why the Lapentas are so important." />
+	<key id="831180407001670" npc="오두막 할아범" name="The Lapentas are holy relics created by the sages who had been endowed with divine power. They were created for performing a purification ritual after sealing the darkness." />
+	<key id="831180407001671" npc="오두막 할아범" name="The Green Lapenta keeps the balance of life, the Blue Lapenta governs space, and the Red Lapenta maintains time." />
+	<key id="831180407001672" npc="오두막 할아범" name="Currently, these three &lt;font color=&quot;#ffd200&quot;lapentas&lt;/font&gt; are being used as barriers to seal the darkness.&#x0A;However, there is a rumor that it was not truly sealed. It is said that, in reality, the &lt;font color=&quot;#ffd200&quot;&gt;Seven Heroes&lt;/font&gt; are the ones keeping the world safe from it.&#x0A;How is it? Has your curiosity regarding the &lt;font color=&quot;#ffd200&quot;&gt;Lapentas&lt;/font&gt; been resolved?" />
 	<key id="831180407001673" npc="pc" name="Yep!" />
-	<key id="831180407001674" npc="오두막 할아범" name="$npcName:11000075[gender:1]$ and the Four Heroes helped the sages protect this world against the Demon King. Whose story do you want to hear first?" />
+	<key id="831180407001674" npc="오두막 할아범" name="&lt;font color=&quot;#ffd200&quot;&gt;$npc:11000075[gender:1]$&lt;/font&gt; and the Seven Heroes are valuable people who protected the world with the help of the &lt;font color=&quot;#ffd200&quot;&gt;sages&lt;/font&gt;.&#x0A;Whose story do you want to hear first?" />
 	<key id="831180407001675" npc="pc" name="Let&apos;s start with $npcName:11000075[gender:1]$." />
-	<key id="831180407001676" npc="pc" name="The Four Heroes sound important." />
+	<key id="831180407001676" npc="pc" name="I want you to tell me about the Seven Heroes first." />
 	<key id="831180407001677" npc="pc" name="How about a different old story?" />
-	<key id="831180407001678" npc="오두막 할아범" name="There has been an empress born to each generation of humans, destined to deliver the will of the divine as their messenger." />
-	<key id="831180407001679" npc="오두막 할아범" name="The empresses are selected by the will of the divine. The $npcName:11000075[gender:1]$ was chosen a long time ago and inherited the title from her predecessor." />
-	<key id="831180407001680" npc="오두막 할아범" name="After the three sages perished and left behind the Lapentas, the $npcName:11000075[gender:1]$ became the spiritual leader of Maple World. She was instrumental in rebuilding society after the Demon King nearly destroyed everything." />
-	<key id="831180407001681" npc="오두막 할아범" name="In the early stages of Maple World&apos;s reconstruction, the $npcName:11000075[gender:1]$ would hold open courts to allow the people to speak to her. In time, however, she ceased this practice." />
-	<key id="831180407001682" npc="오두막 할아범" name="There has been much speculation over why she stopped holding court. Some said the $npcName:11000075[gender:1]$ was struck down by illness. Others said she was abducted by the reawakened Demon King." />
-	<key id="831180407001685" npc="오두막 할아범" name="The Four Heroes are gone now, but their legend will live on. It is rare to find someone who does not know their names." />
-	<key id="831180407001686" npc="오두막 할아범" name="There was the mysterious mage Lewit from Ellin Forest, hot-headed warrior Ten from the holy Vayar Mountains, righteous archer Haster from the Green Meadows, and carefree thief Catarva from Kerningdom." />
-	<key id="831180407001687" npc="오두막 할아범" name="The warrior Ten fell in battle against the Demon King himself. The other three heroes were asked by the $npcName:11000075[gender:1]$ to protect the Lapentas, rather than sacrifice themselves." />
+	<key id="831180407001678" npc="오두막 할아범" name="The Goddess of Light sacrificed herself to save the world from the &lt;font color=&quot;#ffd200&quot;&gt;darkness&lt;/font&gt;, and gathered her remaining power before disappearing, leaving a being to replace her." />
+	<key id="831180407001679" npc="오두막 할아범" name="That being is Empress &lt;font color=&quot;#ffd200&quot;&gt;$npc:11000075[gender:1]$&lt;/font&gt;, the great protector." />
+	<key id="831180407001680" npc="오두막 할아범" name="As the symbol of light and a spiritual pillar of the Maple World, Ereve played a major role in rebuilding the world as it is today." />
+	<key id="831180407001681" npc="오두막 할아범" name="After the reconstruction, she showed a lot of comfort and strength to people through public &lt;font color=&quot;#ffd200&quot;&gt;courts&lt;/font&gt; every year... But she stopped at some point.&#x0A;There is a lot of speculation about why, but there must have been a solid reason." />
+	<key id="831180407001682" npc="오두막 할아범" name="Fortunately, from this year on, the &lt;font color=&quot;#ffd200&quot;&gt;court&lt;/font&gt; will be held again.&#x0A;If you attend this &lt;font color=&quot;#ffd200&quot;&gt;court&lt;/font&gt;, you will probably be able to see the Empress in person.&#x0A;How is it? Are your questions about $npc:11000075[gender:1]$ cleared up?" />
+	<key id="831180407001685" npc="오두막 할아범" name="The &lt;font color=&quot;#ffd200&quot;&gt;Seven Heroes&lt;/font&gt; are legendary warriors who fought against the &lt;font color=&quot;#ffd200&quot;&gt;darkness&lt;/font&gt; with the Empress.&#x0A;According to the stories, the Seven Heroes…" />
+	<key id="831180407001686" npc="오두막 할아범" name="Were, with great focus on, the &lt;font color=&quot;#ffd200&quot;&gt;Mage of Light Cerian&lt;/font&gt;, the &lt;font color=&quot;#ffd200&quot;&gt;Archmage Asimov&lt;/font&gt;, &lt;font color=&quot;#ffd200&quot;&gt;Elder Manovich&lt;/font&gt;, &lt;font color=&quot;#ffd200&quot;&gt;War Chief Wolf Heart&lt;/font&gt;, &lt;font color=&quot;#ffd200&quot;&gt;Captain Winn Stilton&lt;/font&gt;, &lt;font color=&quot;#ffd200&quot;&gt;Guardian Priestess Luanna&lt;/font&gt; and &lt;font color=&quot;#ffd200&quot;&gt;Souls&#39; Balon&lt;/font&gt;." />
+	<key id="831180407001687" npc="오두막 할아범" name="Some of them lost their lives or disappeared in the war against the &lt;font color=&quot;#ffd200&quot;&gt;darkness&lt;/font&gt;, and some were tasked by the Empress with keeping the &lt;font color=&quot;#ffd200&quot;&gt;Lapentas&lt;/font&gt; safe.&#x0A;How is it? Are your questions about the Seven Heroes cleared up a bit?" />
 	<key id="831180407001693" npc="오두막 할아범" name="Not much is known about the Demon King. He was powerful enough to bring Maple World to its knees, and no one who challenged him lived to tell about it." />
 	<key id="831180407001694" npc="오두막 할아범" name="No one knows where he came from, how he came to be, or what made him so powerful." />
 	<key id="831180407001695" npc="오두막 할아범" name="What everyone DOES know is that the Demon King hails from a world of death, despair, and fear, permeated by the power of darkness that he wields so brutally." />
@@ -8544,7 +8544,7 @@
 	<key id="831180407001697" npc="오두막 할아범" name="So long as the protective ward of the Lapentas lasts, Maple World will be safe. But there is always the fear that the Shadow World will find new ways into our world, and destroy it." />
 	<key id="831180407001698" npc="오두막 할아범" name="So, somewhere beyond the reaches of our peaceful, idyllic Maple World lies a realm of pure darkness and terror that seeks to destroy us all. Does that answer your question?" />
 	<key id="831180407001699" npc="pc" name="Yep!" />
-	<key id="831180407001700" npc="오두막 할아범" name="About the present, eh? All right, what do you want to know?" />
+	<key id="831180407001700" npc="오두막 할아범" name="Maple World... It is where you will have adventures in the future, so it is only natural you&#39;re curious about it.&#x0A;Let&#39;s see... Where to begin?" />
 	<key id="831180407001704" npc="오두막 할아범" name="Maple World is a collection of continents floating in a vast, endless ocean. The biggest continent of all is Victoria Island." />
 	<key id="831180407001705" npc="오두막 할아범" name="Victoria Island consists of the capital city of $map:02000001$, where $npcName:11000075[gender:1]$&lt;/font&gt;&apos;s palace stands, $map:02000076$, $map:02000023$, $map:02000051$, and $map:02000100$. Each of these areas has developed its own unique culture." />
 	<key id="831180407001706" npc="오두막 할아범" name="Among them, $map:02000001$ is a metropolis built around the $npcName:11000075[gender:1]$&apos;s palace and protected by massive castle walls. It&apos;s the political, economic, and cultural center of Maple World." />
@@ -19697,10 +19697,10 @@
 	<key id="1101162707015463" feature="Wedding" npc="위즈 하모니" name="$MyPCName$님~! 어서 와. 내 도움이 필요한가요?" />
 	<key id="1101162707015464" feature="Wedding" npc="pc" name="결혼식장 예약을 변경하고 싶다고 한다." />
 	<key id="1101162707015466" feature="Wedding" npc="위즈 하모니" name="알~겠어. 금방 도와줄게요! " />
-	<key id="1101162707015467" feature="Wedding" npc="위즈 하모니" name="네, 우선 예약 정보를 확인하시고 최종 결정을 내려 주세요. &#x0A;상대방이 예약 취소에 동의한다면, 추후 &lt;font color=&quot;#ffd200&quot;&gt;동일 등급의 결혼식장을 예약할 수 있는 무료 예약 쿠폰&lt;/font&gt;을 드립니다. 쿠폰은 획득 후 30일간 유효하니 반드시 유효기간 내 사용해 주시기 바랍니다.&#x0A;상대방이 동의하지 않으면 무료 예약 쿠폰이 지급되지 않습니다. " />
-	<key id="1101173110001798" npc="트루" name="You want to go to $map:02000001$? Why are you asking me? You should go to the Chief." />
-	<key id="1101173110001799" npc="pc" name="I thought sea dogs were adventurous, and yet you won&apos;t even let a friendly stranger onto your boat?" />
-	<key id="1101173110001800" npc="트루" name="You sail to $map:02000001$ by first going to $map:02000062$, and right now the water&apos;s too choppy for this boat. Besides, when conditions are like that, only the Chief can authorize the departure of a large ship." />
+	<key id="1101162707015467" feature="Wedding" npc="위즈 하모니" name="Yes, please check the reservation information first and make the final decision. If the other party agrees to cancel the reservation, we will give you a &lt;font color=&quot;#ffd200&quot;&gt;free reservation coupon to reserve a wedding venue of the same class&lt;/font&gt; in the future. The coupons are valid for 30 days after acquisition, so be sure to use them within the validity period. If the other party does not agree, the free reservation coupon will not be given. " />
+	<key id="1101173110001798" npc="트루" name="Did you come here to take the boat to $map:02000062$?" />
+	<key id="1101173110001799" npc="pc" name="That&quot;s right." />
+	<key id="1101173110001800" npc="트루" name="What should I do...&#x0A;There are so many people leaving for $map:02000062$ for the Empress’s court, so I think we will have to wait a little longer for the boat to be ready…" />
 	<key id="1102131310001928" npc="생일기념파티" name="Happy birthday!" />
 	<key id="1102131310001929" npc="생일기념파티" name="Come see me on the month of your birthday—that is, the anniversy of the month you created your account. You&apos;ll get a special birthday blessing and gift!" />
 	<key id="1102172107011621" feature="Kritias_2018_12" npc="미카" name="I&apos;ve got a bad feeling…" />
@@ -23124,17 +23124,17 @@
 	<key id="1231140707012489" feature="Kritias_2018_12" npc="칸타타" name="You know what that means?" />
 	<key id="1231140707012490" feature="Kritias_2018_12" npc="pc" name="I&apos;m sure it&apos;s nothing." />
 	<key id="1231140707012491" feature="Kritias_2018_12" npc="칸타타" name="I&apos;ll let you know if I learn anything else. This investigation is just getting started!" />
-	<key id="224837599460589655" name='$map:02000062$$pp2:로,으로$ 떠나는 배를 겨우 준비했네.&#x0A;단돈 &lt;font color=&quot;#ffd200&quot;&gt;100메소&lt;/font&gt;만 내면 $map:02000062$$pp2:로,으로$ 떠나는 배를 당장 탈 수 있는데… &#x0A;지금 바로 떠나겠나?' />
-	<key id="224837599460589656" name='그동안 뱃삯도 모을 겸 마을 주민들 부탁도 좀 들어주면서, &#x0A;시간 좀 보내다가 다시 오게나. 참고로 뱃삯은 &lt;font color=&quot;#ffd200&quot;&gt;100메소&lt;/font&gt;라네.' />
-	<key id="224837599460589657" name="아니라고 한다." />
-	<key id="224837599460589658" name='$map:02000062$$pp2:로,으로$ 떠나는 배를 겨우 준비했네.&#x0A;뱃삯은 &lt;font color=&quot;#ffd200&quot;&gt;100메소&lt;/font&gt;네만… 자네는 돈이 부족한 것 같군.&#x0A;배를 공짜로 태워줄 수는 없다네.' />
-	<key id="526984142097743950" npc="오두막 할아범" name='지금 우리가 살고 있는 메이플 월드는 끝이 보이지 않는 광활한&#x0A;바다 위에 크고 작은 대륙이 섬처럼 떠 있지.&#x0A;그 중 가장 큰 중심 대륙이 바로 &lt;font color=&quot;#ffd200&quot;&gt;빅토리아 아일랜드&lt;/font&gt;지.' />
-	<key id="526984142097743954" npc="오두막 할아범" name='&lt;font color=&quot;#ffd200&quot;&gt;빅토리아 아일랜드&lt;/font&gt;에는 &lt;font color=&quot;#ffd200&quot;&gt;$npc:11000075[gender:1]$&lt;/font&gt;님의 왕궁이 자리잡은 대도시&#x0A;&lt;font color=&quot;#ffd200&quot;&gt;$map:02000001$&lt;/font&gt;$pp:를,을$ 중심으로 &lt;font color=&quot;#ffd200&quot;&gt;$map:02000076$&lt;/font&gt;, &lt;font color=&quot;#ffd200&quot;&gt;$map:02000023$&lt;/font&gt;, &lt;font color=&quot;#ffd200&quot;&gt;$map:02000051$&lt;/font&gt;, &lt;font color=&quot;#ffd200&quot;&gt;$map:02000100$&lt;/font&gt; 등이&#x0A;각기 개성있는 지역 문화를 형성하고 있다네.' />
-	<key id="526984142097743955" npc="오두막 할아범" name='예전에는 우리 메이플 아일랜드의 많은 젊은이들이 모험과 새로운 &#x0A;도전을 꿈꾸며 먼 바닷길을 지나 &lt;font color=&quot;#ffd200&quot;&gt;빅토리아 아일랜드&lt;/font&gt;로 떠났었지.&#x0A;나도 소싯적에 그랬고 말이야… 허허허. &#x0A;그러고 보니 내가 이 오두막 밖으로 나가 본 지도 꽤 되었군.' />
-	<key id="526984142097743956" npc="오두막 할아범" name="오랜 세월이 흘렀으니 세상도 아마 많이 바뀌었을 거야.&#x0A;이 늙은이 말을 듣는 것보다 자네가 직접 가서 보고 듣는 게 좋을 거야. &#x0A;더 듣고 싶은 이야기가 있나?" />
-	<key id="526984142097743957" name="그렇다고 한다." />
-	<key id="526984142097743958" name="그렇다고 한다." />
-	<key id="526984142097743959" name="그렇다고 한다." />
+	<key id="224837599460589655" name='We&#39;ve just barely prepared our ship for $map:02000062$.&#x0A;For just &lt;font color=&quot;#ffd200&quot;&gt;100 mesos&lt;/font&gt;, you can catch a boat to $map:02000062$ right away... Would you like to leave right now?' />
+	<key id="224837599460589656" name='In the meantime, let&#39;s spend some time and collect some fare money from the villagers on the way back as well. By the way, the boat fare is &lt;font color=&quot;#ffd200&quot;&gt;100 mesos&lt;/font&gt;.' />
+	<key id="224837599460589657" name="No." />
+	<key id="224837599460589658" name='We&#39;ve just barely prepared our ship for $map:02000062$.&#x0A;The fare is only &lt;font color=&quot;#ffd200&quot;&gt;100 mesos&lt;/font&gt;...&#x0A;Looks like you&#39;re short on money. I can&#39;t give you a boat ride for free.' />
+	<key id="526984142097743950" npc="오두막 할아범" name='Maple World is a collection of continents floating in a vast, endless ocean. The biggest continent of all is &lt;font color=&quot;#ffd200&quot;&gt;Victoria Island&lt;/font&gt;.' />
+	<key id="526984142097743954" npc="오두막 할아범" name='&lt;font color=&quot;#ffd200&quot;&gt;Victoria Island&lt;/font&gt; consists of the capital city of &lt;font color=&quot;#ffd200&quot;&gt;$map:02000001$&lt;/font&gt;, where &lt;font color=&quot;#ffd200&quot;&gt;$npcName:11000075[gender:1]&lt;/font&gt;&#39;s palace stands, &lt;font color=&quot;#ffd200&quot;&gt;$map:02000076$&lt;/font&gt;, &lt;font color=&quot;#ffd200&quot;&gt;$map:02000023$&lt;/font&gt;, &lt;font color=&quot;#ffd200&quot;&gt;$map:02000051$&lt;/font&gt;, and &lt;font color=&quot;#ffd200&quot;&gt;$map:02000100$&lt;/font&gt;. Each of these areas has developed its own unique culture.' />
+	<key id="526984142097743955" npc="오두막 할아범" name='In my time, a great many young people left their homes on Maple Island and traveled across the vast oceans, dreaming of adventures and new challenges that awaited them on &lt;font color=&quot;#ffd200&quot;&gt;Victoria Island&lt;/font&gt;.&#x0A;I was like that too when I was a kid... Heh heh heh.&#x0A;Come to think of it, I haven&apos;t left this cabin for a long time.' />
+	<key id="526984142097743956" npc="오두막 할아범" name="Many years have passed and the world has probably changed a lot. It would be better for you to go and see it for yourself rather than to listen to this old man.&#x0A;Is there any story other you would like to hear ?" />
+	<key id="526984142097743957" name="Yes." />
+	<key id="526984142097743958" name="Yes." />
+	<key id="526984142097743959" name="Yes." />
 	<key id="856579378342002766" name="$item:30000181$$pp:를,을$ 10개 주겠다고 한다." />
 	<key id="856579378342002767" name="$item:30000181$$pp:를,을$ 100개 주겠다고 한다." />
 	<key id="856579378342002768" locale="KR" npc="나탈리" name="$item:30000181$$pp:를,을$ 구하셨다니…&#x0A;메이플 월드의 안전을 지킨 것은 물론이거니와&#x0A;어둠의 땅이 지닌 비밀을 밝힐 단서를 구한 셈이에요!" />


### PR DESCRIPTION
scriptquest:
>Translated quests 10001000, 10001001, 10001110, 10001111, 10001140, 10001780, 40001000
Quest names and descriptions to be translated after patch.

scriptnpc:
>Translated strings:
831180407001655
831180407001656
831180407001659
831180407001666
831180407001667
831180407001668
831180407001670
831180407001672
831180407001674
831180407001678*
831180407001679**
831180407001680
831180407001681
831180407001682
831180407001685
831180407001686
831180407001687
1101162707015467
1101173110001798
1101173110001799
1101173110001800
224837599460589655
224837599460589656
224837599460589658
526984142097743950
526984142097743954
526984142097743955
526984142097743956
526984142097743956
526984142097743957
526984142097743958
526984142097743959

INFO:
*-831180407001678's true translation would be "The Goddess of Light sacrificed herself to save the world from the darkness, and gathered her remaining power before disappearing, leaving a being to replace her. That being is Empress Ereve." However, the last sentence was moved to 831180407001679 for the reasons below.
**-831180407001679's true translation would be "The empresses are selected by the will of the divine, and it is said that Empress Ereve succeeded the previous empress long ago, accepting her fate and ascending to that role.". However, that is simply not canon and a mistake the GMs made when rewriting pre-restart lore dialog to fit current lore.